### PR TITLE
Fetch metrics fix

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -17,10 +17,11 @@ rules:
   resources: ["ingresses"]
   verbs:
     - list
-- apiGroups: ["metrics"]
+- apiGroups: ["metrics.k8s.io"]
   resources: ["nodes", "pods"]
   verbs:
     - get
+    - list
 - apiGroups: [""]
   resources: ["services/proxy"]
   resourceNames: ["heapster"]

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -148,6 +148,8 @@ def query_cluster(
                     logger.warning("Failed to query metrics: %s", e)
                 else:
                     raise
+            if response.ok:
+                break
         for item in response.json()["items"]:
             key = item["metadata"]["name"]
             node = nodes.get(key)
@@ -240,6 +242,8 @@ def query_cluster(
                     logger.warning("Failed to query metrics: %s", e)
                 else:
                     raise
+            if response:
+                break
         for item in response.json()["items"]:
             key = (item["metadata"]["namespace"], item["metadata"]["name"])
             pod = pods.get(key)

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -242,7 +242,7 @@ def query_cluster(
                     logger.warning("Failed to query metrics: %s", e)
                 else:
                     raise
-            if response:
+            if response.ok:
                 break
         for item in response.json()["items"]:
             key = (item["metadata"]["namespace"], item["metadata"]["name"])


### PR DESCRIPTION
This PR contains two parts:

1. the api group for the metrics-server changes from version 0.1.x to 0.2.x , from `metrics` to `metrics.k8s.io`, see https://github.com/kubernetes-incubator/metrics-server#deployment
2. the metrics api call is now done for both api groups , the one from the metrics-server and the one from
 heapster , one of the both must be deployed in the server: 
    * when the first call to metrics server is successful there is no need to call the also the heapster api since they provide the same data
    * when the metrics-server call fails call the heapster api


in the current state we would also call the heapster api and this fails, the response is empty and therefor no values to process for the actual used ressources
 