### PR TITLE
add option for alternative pricing file

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pricing-file
+  namespace: default
+data:
+  pricing.csv: |+
+    dc-1,master,30.000
+    dc-1,worker,500.000

--- a/deploy/deployment-with-cm.yaml
+++ b/deploy/deployment-with-cm.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    application: kube-resource-report
+    version: v0.2.1
+  name: kube-resource-report
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      application: kube-resource-report
+  template:
+    metadata:
+      labels:
+        application: kube-resource-report
+        version: v0.2.1
+    spec:
+      serviceAccount: kube-resource-report
+      containers:
+      - name: kube-resource-report
+        # see https://github.com/hjacobs/kube-resource-report/releases
+        image: hjacobs/kube-resource-report:0.2.1
+        args:
+        - --update-interval-minutes=1
+        - "--pricing-file=/pricing-file/pricing.csv"
+        - /output
+        volumeMounts:
+        - mountPath: /output
+          name: report-data
+        - mountPath: /pricing-file/
+          name: pricing-file
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 5m
+            memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+      - name: nginx
+        image: nginx:alpine
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html
+          name: report-data
+          readOnly: true
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+        resources:
+          limits:
+            memory: 50Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi
+      volumes:
+          - name: report-data
+            emptyDir: {}
+            sizeLimit: 500Mi
+          - name: pricing-file
+            configMap:
+              name: pricing-file
+
+
+

--- a/kube_resource_report/main.py
+++ b/kube_resource_report/main.py
@@ -77,6 +77,11 @@ class CommaSeparatedValues(click.ParamType):
     help="Update the report every X minutes (default: run once and exit)",
     default=0,
 )
+@click.option(
+    "--alternate-pricing-file",
+    type=click.Path(exists=True),
+    help="Path to alternate pricing file"
+)
 @click.argument("output_dir", type=click.Path(exists=True))
 def main(
     clusters,
@@ -92,6 +97,7 @@ def main(
     exclude_clusters,
     additional_cost_per_cluster,
     update_interval_minutes,
+    alternate_pricing_file,
 ):
     """Kubernetes Resource Report
 
@@ -102,6 +108,9 @@ def main(
         kubeconfig_path = Path(kubeconfig_path)
     else:
         kubeconfig_path = Path(os.path.expanduser("~/.kube/config"))
+
+    if alternate_pricing_file:
+        alternate_pricing_file = Path(alternate_pricing_file)
 
     while True:
         generate_report(
@@ -117,6 +126,7 @@ def main(
             include_clusters,
             exclude_clusters,
             additional_cost_per_cluster,
+            alternate_pricing_file,
         )
         if update_interval_minutes > 0:
             time.sleep(update_interval_minutes * 60)

--- a/kube_resource_report/main.py
+++ b/kube_resource_report/main.py
@@ -78,7 +78,7 @@ class CommaSeparatedValues(click.ParamType):
     default=0,
 )
 @click.option(
-    "--alternate-pricing-file",
+    "--pricing-file",
     type=click.Path(exists=True),
     help="Path to alternate pricing file"
 )
@@ -97,7 +97,7 @@ def main(
     exclude_clusters,
     additional_cost_per_cluster,
     update_interval_minutes,
-    alternate_pricing_file,
+    pricing_file,
 ):
     """Kubernetes Resource Report
 
@@ -109,8 +109,8 @@ def main(
     else:
         kubeconfig_path = Path(os.path.expanduser("~/.kube/config"))
 
-    if alternate_pricing_file:
-        alternate_pricing_file = Path(alternate_pricing_file)
+    if pricing_file:
+        pricing_file = Path(pricing_file)
 
     while True:
         generate_report(
@@ -126,7 +126,7 @@ def main(
             include_clusters,
             exclude_clusters,
             additional_cost_per_cluster,
-            alternate_pricing_file,
+            pricing_file,
         )
         if update_interval_minutes > 0:
             time.sleep(update_interval_minutes * 60)

--- a/kube_resource_report/pricing.py
+++ b/kube_resource_report/pricing.py
@@ -27,7 +27,7 @@ with spot_path.open() as fd:
         NODE_SPOT_COSTS_MONTHLY[(region, instance_type)] = float(monthly_cost)
 
 
-def get_node_cost(alternate_pricing_file, region, instance_type, is_spot):
+def get_node_cost(pricing_file, region, instance_type, is_spot):
     if is_spot:
         cost = NODE_SPOT_COSTS_MONTHLY.get((region, instance_type))
         if cost is None:

--- a/kube_resource_report/pricing.py
+++ b/kube_resource_report/pricing.py
@@ -26,6 +26,7 @@ with spot_path.open() as fd:
         region, instance_type, monthly_cost = row
         NODE_SPOT_COSTS_MONTHLY[(region, instance_type)] = float(monthly_cost)
 
+
 def regenerate_cost_dict(pricing_file):
     # Reset the costs dict and fill it with data from the external pricing file
     NODE_COSTS_MONTHLY = {}
@@ -36,6 +37,7 @@ def regenerate_cost_dict(pricing_file):
             region, instance_type, monthly_cost = row
             NODE_COSTS_MONTHLY[(region, instance_type)] = float(monthly_cost)
     return NODE_COSTS_MONTHLY
+
 
 def get_node_cost(region, instance_type, is_spot):
     if is_spot:

--- a/kube_resource_report/pricing.py
+++ b/kube_resource_report/pricing.py
@@ -26,8 +26,18 @@ with spot_path.open() as fd:
         region, instance_type, monthly_cost = row
         NODE_SPOT_COSTS_MONTHLY[(region, instance_type)] = float(monthly_cost)
 
+def regenerate_cost_dict(pricing_file):
+    # Reset the costs dict and fill it with data from the external pricing file
+    NODE_COSTS_MONTHLY = {}
+    path = pricing_file
+    with path.open() as fd:
+        reader = csv.reader(fd)
+        for row in reader:
+            region, instance_type, monthly_cost = row
+            NODE_COSTS_MONTHLY[(region, instance_type)] = float(monthly_cost)
+    return NODE_COSTS_MONTHLY
 
-def get_node_cost(pricing_file, region, instance_type, is_spot):
+def get_node_cost(region, instance_type, is_spot):
     if is_spot:
         cost = NODE_SPOT_COSTS_MONTHLY.get((region, instance_type))
         if cost is None:

--- a/kube_resource_report/pricing.py
+++ b/kube_resource_report/pricing.py
@@ -27,7 +27,7 @@ with spot_path.open() as fd:
         NODE_SPOT_COSTS_MONTHLY[(region, instance_type)] = float(monthly_cost)
 
 
-def get_node_cost(region, instance_type, is_spot):
+def get_node_cost(alternate_pricing_file, region, instance_type, is_spot):
     if is_spot:
         cost = NODE_SPOT_COSTS_MONTHLY.get((region, instance_type))
         if cost is None:

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -85,7 +85,7 @@ logger = logging.getLogger(__name__)
 
 
 def query_cluster(
-    cluster, executor, system_namespaces, additional_cost_per_cluster, no_ingress_status, pricing_file
+    cluster, executor, system_namespaces, additional_cost_per_cluster, no_ingress_status
 ):
     logger.info("Querying cluster {} ({})..".format(cluster.id, cluster.api_server_url))
     pods = {}
@@ -129,7 +129,7 @@ def query_cluster(
         )
         node["role"] = role
         node["instance_type"] = instance_type
-        node["cost"] = pricing.get_node_cost(pricing_file, region, instance_type, is_spot)
+        node["cost"] = pricing.get_node_cost(region, instance_type, is_spot)
         cluster_cost += node["cost"]
 
     try:
@@ -308,7 +308,6 @@ def get_cluster_summaries(
     notifications: list,
     additional_cost_per_cluster: float,
     no_ingress_status: bool,
-    pricing_file: Path,
 ):
     cluster_summaries = {}
 
@@ -339,7 +338,6 @@ def get_cluster_summaries(
                         system_namespaces,
                         additional_cost_per_cluster,
                         no_ingress_status,
-                        pricing_file,
                     )
                 ] = cluster
 
@@ -457,6 +455,9 @@ def generate_report(
 
     output_path = Path(output_dir)
 
+    if pricing_file:
+        pricing.NODE_COSTS_MONTHLY = pricing.regenerate_cost_dict(pricing_file)
+
     start = datetime.datetime.utcnow()
 
     pickle_path = output_path / "dump.pickle"
@@ -480,7 +481,6 @@ def generate_report(
             notifications,
             additional_cost_per_cluster,
             no_ingress_status,
-            pricing_file,
         )
         teams = {}
         applications = {}

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -85,7 +85,7 @@ logger = logging.getLogger(__name__)
 
 
 def query_cluster(
-    cluster, executor, system_namespaces, additional_cost_per_cluster, no_ingress_status
+    cluster, executor, system_namespaces, additional_cost_per_cluster, no_ingress_status, alternate_pricing_file
 ):
     logger.info("Querying cluster {} ({})..".format(cluster.id, cluster.api_server_url))
     pods = {}
@@ -129,7 +129,7 @@ def query_cluster(
         )
         node["role"] = role
         node["instance_type"] = instance_type
-        node["cost"] = pricing.get_node_cost(region, instance_type, is_spot)
+        node["cost"] = pricing.get_node_cost(alternate_pricing_file, region, instance_type, is_spot)
         cluster_cost += node["cost"]
 
     try:
@@ -308,6 +308,7 @@ def get_cluster_summaries(
     notifications: list,
     additional_cost_per_cluster: float,
     no_ingress_status: bool,
+    alternate_pricing_file: str,
 ):
     cluster_summaries = {}
 
@@ -338,6 +339,7 @@ def get_cluster_summaries(
                         system_namespaces,
                         additional_cost_per_cluster,
                         no_ingress_status,
+                        alternate_pricing_file,
                     )
                 ] = cluster
 
@@ -449,6 +451,7 @@ def generate_report(
     include_clusters,
     exclude_clusters,
     additional_cost_per_cluster,
+    alternate_pricing_file,
 ):
     notifications = []
 
@@ -477,6 +480,7 @@ def generate_report(
             notifications,
             additional_cost_per_cluster,
             no_ingress_status,
+            alternate_pricing_file,
         )
         teams = {}
         applications = {}

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -85,7 +85,7 @@ logger = logging.getLogger(__name__)
 
 
 def query_cluster(
-    cluster, executor, system_namespaces, additional_cost_per_cluster, no_ingress_status, alternate_pricing_file
+    cluster, executor, system_namespaces, additional_cost_per_cluster, no_ingress_status, pricing_file
 ):
     logger.info("Querying cluster {} ({})..".format(cluster.id, cluster.api_server_url))
     pods = {}
@@ -129,7 +129,7 @@ def query_cluster(
         )
         node["role"] = role
         node["instance_type"] = instance_type
-        node["cost"] = pricing.get_node_cost(alternate_pricing_file, region, instance_type, is_spot)
+        node["cost"] = pricing.get_node_cost(pricing_file, region, instance_type, is_spot)
         cluster_cost += node["cost"]
 
     try:
@@ -308,7 +308,7 @@ def get_cluster_summaries(
     notifications: list,
     additional_cost_per_cluster: float,
     no_ingress_status: bool,
-    alternate_pricing_file: str,
+    pricing_file: Path,
 ):
     cluster_summaries = {}
 
@@ -339,7 +339,7 @@ def get_cluster_summaries(
                         system_namespaces,
                         additional_cost_per_cluster,
                         no_ingress_status,
-                        alternate_pricing_file,
+                        pricing_file,
                     )
                 ] = cluster
 
@@ -451,7 +451,7 @@ def generate_report(
     include_clusters,
     exclude_clusters,
     additional_cost_per_cluster,
-    alternate_pricing_file,
+    pricing_file,
 ):
     notifications = []
 
@@ -480,7 +480,7 @@ def generate_report(
             notifications,
             additional_cost_per_cluster,
             no_ingress_status,
-            alternate_pricing_file,
+            pricing_file,
         )
         teams = {}
         applications = {}

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -45,5 +45,6 @@ def test_generate_report(tmpdir, monkeypatch):
         None,
         None,
         0,
+        None,
     )
     assert len(cluster_summaries) == 1


### PR DESCRIPTION
With this PR we can use an alternative pricing file instead the builtin file, so we can kube-resource-report also on non AWS Kubernetes clusters.

You can provide this file via volume mount, i added an example where i use a configmap to provide this file via volume mount.

It is still in the responsibility of the cluster admin to add the corresponding labels to the nodes in the cluster:
```
kubectl label nodes master beta.kubernetes.io/instance-type=master
kubectl label nodes master failure-domain.beta.kubernetes.io/region=dc-1
```

