### PR TITLE
Add nano as unit

### DIFF
--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -32,6 +32,7 @@ HOURS_PER_DAY = 24
 HOURS_PER_MONTH = HOURS_PER_DAY * AVG_DAYS_PER_MONTH
 
 FACTORS = {
+    "n": 1 / 1000000000,
     "m": 1 / 1000,
     "K": 1000,
     "M": 1000 ** 2,


### PR DESCRIPTION
metrics-server version  0.3 and above reports cpu usage in nano cores:

```
...
    {
      "metadata": {
        "name": "worker03",
        "selfLink": "/apis/metrics.k8s.io/v1beta1/nodes/worker03",
        "creationTimestamp": "2018-09-21T17:53:35Z"
      },
      "timestamp": "2018-09-21T17:53:19Z",
      "window": "30s",
      "usage": {
        "cpu": "78061175n",
        "memory": "631612Ki"
      }
    }
...
```