### PR TITLE
Use a user-friendly cluster name where possible

### DIFF
--- a/kube_resource_report/templates/cluster.html
+++ b/kube_resource_report/templates/cluster.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% block title %}Cluster {{ cluster_id }}{% endblock %}
+{% block title %}Cluster {{ summary.cluster.name }}{% endblock %}
 {% block content %}
-<h1 class="title">Cluster {{ cluster_id }}</h1>
-<h2 class="subtitle">{{ summary.cluster.api_server_url }}</h1>
+<h1 class="title">Cluster {{ summary.cluster.name }}</h1>
+<h2 class="subtitle">{{ summary.cluster.id }}</h1>
 
 <nav class="level">
   <div class="level-item has-text-centered">
@@ -157,7 +157,7 @@
           </thead>
           <tbody>
           {% for namespace_id, namespace_data in namespace_usage.items()|sort: %}
-          {% if namespace_data.cluster == cluster_id %}
+          {% if namespace_data.cluster.id == cluster_id %}
           <tr>
             <td>{{ namespace_id[0] }}</td>
             <td>

--- a/kube_resource_report/templates/clusters.html
+++ b/kube_resource_report/templates/clusters.html
@@ -4,8 +4,7 @@
       <table class="table is-striped" data-sortable>
           <thead>
               <tr>
-                  <th>ID</th>
-                  <th>API URL</th>
+                  <th>Cluster</th>
                   <th><abbr title="Master Nodes">MN</abbr></th>
                   <th><abbr title="Worker Nodes">WN</abbr></th>
                   <th>Inst. Types</th>
@@ -20,10 +19,9 @@
               </tr>
           </thead>
           <tbody>
-          {% for cluster_id, summary in cluster_summaries.items()|sort: %}
+          {% for cluster_id, summary in cluster_summaries.items() %}
           <tr>
-            <td><a href="./cluster-{{ cluster_id }}.html">{{ cluster_id }}</a></td>
-            <td>{{ summary.cluster.api_server_url }}</td>
+            <td><a href="./cluster-{{ cluster_id }}.html">{{ summary.cluster.name }}</a></td>
             <td class="has-text-right">{{ summary.master_nodes }}</td>
             <td class="has-text-right">{{ summary.worker_nodes }}</td>
             <td>{{ summary.worker_instance_types|join(', ') }}</td>

--- a/kube_resource_report/templates/ingresses.html
+++ b/kube_resource_report/templates/ingresses.html
@@ -5,7 +5,7 @@
       <table class="table is-striped" data-sortable>
           <thead>
               <tr>
-                  <th>Cluster ID</th>
+                  <th>Cluster</th>
                   <th>Namespace</th>
                   <th>Name</th>
                   <th>Application</th>
@@ -17,7 +17,7 @@
           {% for cluster_id, summary in cluster_summaries.items(): %}
           {% for ingress in summary.ingresses: %}
           <tr>
-            <td><a href="./cluster-{{ cluster_id }}.html">{{ cluster_id }}</a></td>
+            <td><a href="./cluster-{{ cluster_id }}.html">{{ summary["cluster"].name }}</a></td>
             <td>{{ ingress[0] }}</td>
             <td>{{ ingress[1] }}</td>
             <td>{{ ingress[2] }}</td>

--- a/kube_resource_report/templates/namespaces.html
+++ b/kube_resource_report/templates/namespaces.html
@@ -31,7 +31,7 @@
                 {% endif %}
 
                 </td>
-            <td><a href="./cluster-{{ namespace_data.cluster }}.html">{{ namespace_data.cluster }}</a></td>
+            <td><a href="./cluster-{{ namespace_data.cluster.id }}.html">{{ namespace_data.cluster.name }}</a></td>
             <td>{{ namespace_data.pods }}</td>
             <td>{{ namespace_data.requests.cpu|round(3) }}</td>
             <td data-value="{{ namespace_data.requests.memory }}">{{ namespace_data.requests.memory|filesizeformat(True) }}</td>

--- a/kube_resource_report/templates/pods.html
+++ b/kube_resource_report/templates/pods.html
@@ -5,7 +5,7 @@
       <table class="table is-striped" data-sortable>
           <thead>
               <tr>
-                  <th>Cluster ID</th>
+                  <th>Cluster</th>
                   <th>Namespace</th>
                   <th>Name</th>
                   <th>Application</th>
@@ -20,7 +20,7 @@
           {% for cluster_id, summary in cluster_summaries.items(): %}
           {% for namespace_name, pod in summary.pods.items(): %}
           <tr>
-            <td><a href="./cluster-{{ cluster_id }}.html">{{ cluster_id }}</a></td>
+            <td><a href="./cluster-{{ cluster_id }}.html">{{ summary.cluster.name }}</a></td>
             <td>{{ namespace_name[0] }}</td>
             <td>{{ namespace_name[1] }}</td>
             <td>{{ pod.application }}</td>

--- a/kube_resource_report/templates/team.html
+++ b/kube_resource_report/templates/team.html
@@ -42,8 +42,7 @@
       <table class="table is-striped" data-sortable>
           <thead>
               <tr>
-                  <th>ID</th>
-                  <th>API URL</th>
+                  <th>Cluster</th>
                   <th><abbr title="Master Nodes">MN</abbr></th>
                   <th><abbr title="Worker Nodes">WN</abbr></th>
                   <th>Inst. Types</th>
@@ -57,11 +56,10 @@
               </tr>
           </thead>
           <tbody>
-              {% for cluster_id in team.clusters|sort: %}
+              {% for cluster_id in team.clusters: %}
           {% set summary = cluster_summaries[cluster_id] %}
           <tr>
-            <td><a href="./cluster-{{ cluster_id }}.html">{{ cluster_id }}</a></td>
-            <td>{{ summary.cluster.api_server_url }}</td>
+            <td><a href="./cluster-{{ cluster_id }}.html">{{ summary.cluster.name }}</a></td>
             <td>{{ summary.master_nodes }}</td>
             <td>{{ summary.worker_nodes }}</td>
             <td>{{ summary.worker_instance_types|join(', ') }}</td>

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -9,7 +9,7 @@ def test_generate_report(tmpdir, monkeypatch):
     monkeypatch.setattr("kube_resource_report.cluster_discovery.tokens.get", lambda x: "mytok")
     monkeypatch.setattr(
         "kube_resource_report.cluster_discovery.ClusterRegistryDiscoverer.get_clusters",
-        lambda x: [Cluster("test-cluster-1", "https://test-cluster-1.example.org")],
+        lambda x: [Cluster("test-cluster-1", "test-cluster-1", "https://test-cluster-1.example.org")],
     )
 
     responses = {


### PR DESCRIPTION
Cluster ID and API Server URL are internal details that the users don't care about. Use a user-friendly name where possible (`alias` from CR) and sort on it instead.