### PR TITLE
CommaSeparatedValues() should return `list` instead of `filter`

### DIFF
--- a/kube_resource_report/main.py
+++ b/kube_resource_report/main.py
@@ -12,7 +12,7 @@ class CommaSeparatedValues(click.ParamType):
 
     def convert(self, value, param, ctx):
         if isinstance(value, str):
-            values = filter(None, value.split(","))
+            values = list(filter(None, value.split(",")))
         else:
             values = value
         return values


### PR DESCRIPTION
Fixes the issue with `system_namespaces` being deleted during the first `generate_report()` call when it's provided as an argument to `set()`.

The following example should explain the issue:
```
>>> a=filter(None,{1,2})
>>> print(set(a))
{1, 2}
>>> print(set(a))
set()
```

The issue appears when the `kube_resource_report` is called with multiple values in `--system-namespaces` and non-zero `--update-interval-minutes`, e.g.: `kube_resource_report --update-interval-minutes=1 --system-namespaces=ns1,ns2`.
After the first iteration the `system_namespaces` variable becomes empty. This results to `user_requests` being identical to `requests` and miscalculated `cost_per_user_request_hour` in the `metrics.json`