### PR TITLE
prevent browser sending /favicon.ico request

### DIFF
--- a/kube_resource_report/templates/base.html
+++ b/kube_resource_report/templates/base.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="assets/sortable-theme-minimal.css" />
     <link rel="stylesheet" href="assets/kube-resource-report.css" />
     <link rel="shortcut icon" href="assets/favicon.png">
+    <link rel="icon" href="data:;base64,=">
   </head>
   <body class="has-navbar-fixed-top">
   <nav class="navbar is-fixed-top is-dark" role="navigation" aria-label="main navigation">


### PR DESCRIPTION
Some browsers send silently request to `/favicon.ico`.
The code change prevents doing that.

More info here:
https://stackoverflow.com/questions/1321878/how-to-prevent-favicon-ico-requests

Background:
https://github.bus.zalan.do/pitchfork/developer-console/issues/472

```
[07/Mar/2019:15:46:40 +0000] \"GET /favicon.ico HTTP/1.1\" 404 150 \"https://dev.zalando.net/kube-resource-report/clusters.html\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36\" 16 dev.zalando.net - -\n","stream":"stderr","time":"2019-03-07T15:46:40.256871663Z"}
```