### PR TITLE
Correct deployment yaml

### DIFF
--- a/deploy/deployment-with-cm.yaml
+++ b/deploy/deployment-with-cm.yaml
@@ -60,11 +60,8 @@ spec:
             memory: 20Mi
       volumes:
           - name: report-data
-            emptyDir: {}
-            sizeLimit: 500Mi
+            emptyDir:
+              sizeLimit: 500Mi
           - name: pricing-file
             configMap:
               name: pricing-file
-
-
-

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -59,8 +59,5 @@ spec:
             memory: 20Mi
       volumes:
           - name: report-data
-            emptyDir: {}
-            sizeLimit: 500Mi
-
-
-
+            emptyDir:
+              sizeLimit: 500Mi


### PR DESCRIPTION
Thanks for this nice tool / overview!

I tried running it with a Kubernetes 1.14.0 cluster:

```bash
Client Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.0", GitCommit:"641856db18352033a0d96dbc99153fa3b27298e5", GitTreeState:"clean", BuildDate:"2019-03-26T00:04:52Z", GoVersion:"go1.12.1", Compiler:"gc", Platform:"darwin/amd64"}
```

and noticed that the deployment yaml structure was invalid (at least for 1.14):

```bash
configmap/pricing-file unchanged
serviceaccount/kube-resource-report unchanged
clusterrole.rbac.authorization.k8s.io/kube-resource-report unchanged
clusterrolebinding.rbac.authorization.k8s.io/kube-resource-report unchanged
service/kube-resource-report unchanged
error validating "deploy/deployment-with-cm.yaml": error validating data: ValidationError(Deployment.spec.template.spec.volumes[0]): unknown field "sizeLimit" in io.k8s.api.core.v1.Volume; if you choose to ignore these errors, turn validation off with --validate=false
error validating "deploy/deployment.yaml": error validating data: ValidationError(Deployment.spec.template.spec.volumes[0]): unknown field "sizeLimit" in io.k8s.api.core.v1.Volume; if you choose to ignore these errors, turn validation off with --validate=false
```