### PR TITLE
[chart] Fix clusterrole to permit access to services

### DIFF
--- a/chart/kube-resource-report/templates/clusterrole.yaml
+++ b/chart/kube-resource-report/templates/clusterrole.yaml
@@ -14,9 +14,10 @@ metadata:
   name: {{ include "kube-resource-report.fullname" . }}-clusterrole
 rules:
 - apiGroups: [""]
-  resources: ["nodes", "pods", "namespaces"]
+  resources: ["nodes", "pods", "namespaces", "services"]
   verbs:
     - list
+    - get
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs:


### PR DESCRIPTION
We needed to broaden permissions of kube-resource-report in order to grant read access to `services` and permit `get` for core api groups.