### PR TITLE
[REVIEW] fixed for ugly cluster names

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,8 @@ stups-tokens = "*"
 "jinja2" = "*"
 requests-futures = "*"
 pykube-ng = "*"
+awesome-slugify = "*"
+
 
 [dev-packages]
 flake8 = "*"

--- a/kube_resource_report/output.py
+++ b/kube_resource_report/output.py
@@ -2,6 +2,7 @@ import logging
 import shutil
 
 from pathlib import Path
+from slugify import slugify
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from kube_resource_report import filters
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 class OutputManager:
 
     def __init__(self, output_path: Path):
-        self.output_path = output_path
+        self.output_path = Path(slugify(output_path.name))
         self.written_paths = set()
 
         env = Environment(


### PR DESCRIPTION
When a set of clusters have non posix path format names the output will often fail.
modified to use slug style path names