### PR TITLE
Add team label

### DIFF
--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -33,6 +33,7 @@ NODE_LABEL_INSTANCE_TYPE = os.environ.get("NODE_LABEL_INSTANCE_TYPE", "beta.kube
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
 OBJECT_LABEL_APPLICATION = os.environ.get("OBJECT_LABEL_APPLICATION", "application,app,app.kubernetes.io/name").split(",")
 OBJECT_LABEL_COMPONENT = os.environ.get("OBJECT_LABEL_COMPONENT", "component,app.kubernetes.io/component").split(",")
+OBJECT_LABEL_TEAM = os.environ.get("OBJECT_LABEL_TEAM", "team,owner").split(",")
 
 ONE_MEBI = 1024 ** 2
 ONE_GIBI = 1024 ** 3
@@ -97,6 +98,13 @@ def get_application_from_labels(labels):
 
 def get_component_from_labels(labels):
     for label_name in OBJECT_LABEL_COMPONENT:
+        if label_name in labels:
+            return labels[label_name]
+    return ""
+
+
+def get_team_from_labels(labels):
+    for label_name in OBJECT_LABEL_TEAM:
         if label_name in labels:
             return labels[label_name]
     return ""
@@ -298,6 +306,7 @@ def query_cluster(
             continue
         application = get_application_from_labels(pod.labels)
         component = get_component_from_labels(pod.labels)
+        team = get_team_from_labels(pod.labels)
         requests = collections.defaultdict(float)
         ns = pod.namespace
         container_images = []
@@ -323,6 +332,7 @@ def query_cluster(
             "container_images": container_images,
             "cost": cost,
             "usage": new_resources(),
+            "team": team,
         }
 
     hourly_cost = cluster_cost / HOURS_PER_MONTH
@@ -525,6 +535,37 @@ def resolve_application_ids(applications: dict, teams: dict, application_registr
             teams[team_id] = team
 
 
+def resolve_team_labels(applications: dict, teams: dict):
+    for app in applications.values():
+        if app["team"] != "":
+            team_id = app["team"]
+            app["team"] = team_id
+            app["active"] = True
+            team = teams.get(
+                team_id,
+                {
+                    "clusters": set(),
+                    "applications": set(),
+                    "cost": 0,
+                    "pods": 0,
+                    "requests": {},
+                    "usage": {},
+                    "slack_cost": 0,
+                },
+            )
+            team["applications"].add(app["id"])
+            team["clusters"] |= app["clusters"]
+            team["pods"] += app["pods"]
+            for r in "cpu", "memory":
+                team["requests"][r] = team["requests"].get(
+                    r, 0) + app["requests"][r]
+                team["usage"][r] = team["usage"].get(r, 0) + app.get(
+                    "usage", {}).get(r, 0)
+            team["cost"] += app["cost"]
+            team["slack_cost"] += app["slack_cost"]
+            teams[team_id] = team
+
+
 def calculate_metrics(context: dict) -> dict:
     metrics = {
         "clusters": len(context["cluster_summaries"]),
@@ -646,6 +687,7 @@ def generate_report(
             app["slack_cost"] += pod.get("slack_cost", 0)
             app["pods"] += 1
             app["clusters"].add(cluster_id)
+            app["team"] = pod["team"]
             applications[pod["application"]] = app
 
         for ns_pod, pod in summary["pods"].items():
@@ -676,6 +718,8 @@ def generate_report(
 
     if application_registry:
         resolve_application_ids(applications, teams, application_registry)
+
+    resolve_team_labels(applications, teams)
 
     for team in teams.values():
         def cluster_name(cluster_id):

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -538,11 +538,9 @@ def resolve_application_ids(applications: dict, teams: dict, application_registr
 def resolve_team_labels(applications: dict, teams: dict):
     for app in applications.values():
         if app["team"] != "":
-            team_id = app["team"]
-            app["team"] = team_id
             app["active"] = True
             team = teams.get(
-                team_id,
+                app["team"],
                 {
                     "clusters": set(),
                     "applications": set(),
@@ -563,7 +561,7 @@ def resolve_team_labels(applications: dict, teams: dict):
                     "usage", {}).get(r, 0)
             team["cost"] += app["cost"]
             team["slack_cost"] += app["slack_cost"]
-            teams[team_id] = team
+            teams[app["team"]] = team
 
 
 def calculate_metrics(context: dict) -> dict:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -294,9 +294,9 @@ def test_team_label(fake_applications):
     teams = {}
     resolve_team_labels(fake_applications, teams)
     assert len(teams) == 1
-    team = teams["some-team"]
-    assert team["cost"] == 50
-    assert team["slack_cost"] == 15
-    assert team["pods"] == 2
+    team = teams['some-team']
+    assert team['cost'] == 50
+    assert team['slack_cost'] == 15
+    assert team['pods'] == 2
     assert team['requests'] == {'cpu': 1.2, 'memory': 512 + 1024}
-    assert team["clusters"] == {"some-cluster"}
+    assert team['clusters'] == {'some-cluster'}

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -11,6 +11,7 @@ from kube_resource_report.report import (
     get_pod_usage,
     get_node_usage,
     new_resources,
+    resolve_team_labels,
     NODE_LABEL_ROLE
 )
 
@@ -131,6 +132,36 @@ def fake_node_metric_responses():
                 },
             ]
         }
+    }
+
+
+@pytest.fixture
+def fake_applications():
+    return {
+        "some-app": {
+            "id": "some-app",
+            "team": "some-team",
+            "clusters": {"some-cluster"},
+            "pods": 1,
+            "cost": 40,
+            "slack_cost": 10,
+            "requests": {
+                "cpu": 1,
+                "memory": 1024,
+            },
+        },
+        "some-other-app": {
+            "id": "some-other-app",
+            "team": "some-team",
+            "clusters": {"some-cluster"},
+            "pods": 1,
+            "cost": 10,
+            "slack_cost": 5,
+            "requests": {
+                "cpu": 0.2,
+                "memory": 512,
+            },
+        },
     }
 
 
@@ -257,3 +288,15 @@ def test_get_node_usage(monkeypatch, fake_node_metric_responses):
 def test_more_than_one_label(fake_generate_report, fake_responses_with_two_different_nodes):
     cluster_summaries = fake_generate_report(fake_responses_with_two_different_nodes)
     assert cluster_summaries['test-cluster-1']['worker_nodes'] == 2
+
+
+def test_team_label(fake_applications):
+    teams = {}
+    resolve_team_labels(fake_applications, teams)
+    assert len(teams) == 1
+    team = teams["some-team"]
+    assert team["cost"] == 50
+    assert team["slack_cost"] == 15
+    assert team["pods"] == 2
+    assert team['requests'] == {'cpu': 1.2, 'memory': 512 + 1024}
+    assert team["clusters"] == {"some-cluster"}


### PR DESCRIPTION
This PR enables the usage of the teams overview without having an application registry,
instead it uses a specifiable label on the pod to determine the team.

There are two things I'm unsure about:
* Should `active` be set for a team labeled application?
* Should the user be restricted to either use the application registry or the team label?

#114 