### PR TITLE
Conditional ingress api version

### DIFF
--- a/chart/kube-resource-report/Chart.yaml
+++ b/chart/kube-resource-report/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "19.12.2"
 description: Report Kubernetes cluster and pod resource requests vs usage and generate static HTML
 name: kube-resource-report
-version: 0.2.3
+version: 0.3.0
 home: https://github.com/hjacobs/kube-resource-report.git

--- a/chart/kube-resource-report/templates/_helpers.tpl
+++ b/chart/kube-resource-report/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "kube-resource-report.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for Ingress.
+*/}}
+{{- define "kube-resource-report.ingress.apiVersion" -}}
+{{- if and (ge .Capabilities.KubeVersion.Minor "4") (le .Capabilities.KubeVersion.Minor "13") -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if ge .Capabilities.KubeVersion.Minor "14" -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/chart/kube-resource-report/templates/_helpers.tpl
+++ b/chart/kube-resource-report/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Return the appropriate apiVersion for Ingress.
 */}}
 {{- define "kube-resource-report.ingress.apiVersion" -}}
-{{- if and (ge .Capabilities.KubeVersion.Minor "4") (le .Capabilities.KubeVersion.Minor "13") -}}
+{{- if and (ge .Capabilities.KubeVersion.Minor "9") (le .Capabilities.KubeVersion.Minor "13") -}}
 {{- print "extensions/v1beta1" -}}
 {{- else if ge .Capabilities.KubeVersion.Minor "14" -}}
 {{- print "networking.k8s.io/v1beta1" -}}

--- a/chart/kube-resource-report/templates/ingress.yaml
+++ b/chart/kube-resource-report/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kube-resource-report.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "kube-resource-report.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
- Return the ingress version based on kubernetes minor version. Version 1.14 onwards `networking.k8s.io/v1beta1` is supported