### PR TITLE
show Pod slack costs on the application page

### DIFF
--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -1010,6 +1010,7 @@ def write_report(
                 "CPU Usage",
                 "Memory Usage",
                 "Cost [USD]",
+                "Slack Cost [USD]",
             ]
         )
         with out.open("slack.tsv") as csvfile2:
@@ -1042,6 +1043,7 @@ def write_report(
                             usage["cpu"],
                             usage["memory"],
                             pod["cost"],
+                            pod["slack_cost"],
                         ]
                     )
                 cost_per_cpu = summary["cost"] / summary["allocatable"]["cpu"]

--- a/kube_resource_report/templates/application.html
+++ b/kube_resource_report/templates/application.html
@@ -116,6 +116,7 @@
                   <th>CPU</th>
                   <th>Memory (MiB)</th>
                   <th class="has-text-right">Cost</th>
+                  <th class="has-text-right">Slack Cost</th>
                   {% if links['pod']: %}
                   <th></th>
                   {% endif %}
@@ -152,6 +153,7 @@
             </td>
 
             <td class="has-text-right">{{ row.pod.cost|money }}</td>
+            <td class="has-text-right">{{ row.pod.slack_cost|money }}</td>
 
             {% if links['pod']: %}
             <td class="links">


### PR DESCRIPTION
The slack costs was not shown for Pods on the application page. Add a "Slack Cost" column to make it easier to identify where to optimize.

How it looks:
![pod-slack-costs](https://user-images.githubusercontent.com/510328/77334119-ac964180-6d24-11ea-988e-0f1eeda565e6.png)
