### PR TITLE
Uses all application properties for link formatting

### DIFF
--- a/kube_resource_report/templates/application.html
+++ b/kube_resource_report/templates/application.html
@@ -4,8 +4,8 @@
 <h1 class="title">Application {{ application.id }}
     <span class="links">
         {% for link in links['application']: %}
-             <a href="{{ link.href.format(id=application.id) }}"
-                title="{{ link.title.format(id=application.id) }}"
+             <a href="{{ link.href.format(**application) }}"
+                title="{{ link.title.format(**application) }}"
                 class="button is-light">
                  <span class="icon"><i class="fas fa-{{ link.icon }}"></i></span>
              </a>


### PR DESCRIPTION
This change is required to support multiple variable formatting in application link.

Multiple application properties are already used in two other places:
https://github.com/hjacobs/kube-resource-report/blob/08684404950aed8be4e9df47ad6a94d9300cec59/kube_resource_report/templates/team.html#L204-L206

https://github.com/hjacobs/kube-resource-report/blob/08684404950aed8be4e9df47ad6a94d9300cec59/kube_resource_report/templates/applications.html#L80-L82