### PR TITLE
Add component breakdown to Application page

### DIFF
--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -700,6 +700,7 @@ def generate_report(
                     "cost": 0,
                     "slack_cost": 0,
                     "pods": 0,
+                    "components": {},
                     "requests": {},
                     "usage": {},
                     "clusters": set(),
@@ -707,9 +708,21 @@ def generate_report(
                     "active": None,
                 },
             )
+            component = app["components"].get(pod["component"], {
+                "cost": 0,
+                "slack_cost": 0,
+                "pods": 0,
+                "requests": {},
+                "usage": {},
+                "clusters": set(),
+            })
             for r in "cpu", "memory":
                 app["requests"][r] = app["requests"].get(r, 0) + pod["requests"][r]
                 app["usage"][r] = app["usage"].get(r, 0) + pod.get("usage", {}).get(
+                    r, 0
+                )
+                component["requests"][r] = component["requests"].get(r, 0) + pod["requests"][r]
+                component["usage"][r] = component["usage"].get(r, 0) + pod.get("usage", {}).get(
                     r, 0
                 )
             app["cost"] += pod["cost"]
@@ -717,6 +730,13 @@ def generate_report(
             app["pods"] += 1
             app["clusters"].add(cluster_id)
             app["team"] = pod["team"]
+
+            component["cost"] += pod["cost"]
+            component["slack_cost"] += pod.get("slack_cost", 0)
+            component["pods"] += 1
+            component["clusters"].add(cluster_id)
+
+            app["components"][pod["component"]] = component
             applications[pod["application"]] = app
 
         for ns_pod, pod in summary["pods"].items():

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -708,23 +708,28 @@ def generate_report(
                     "active": None,
                 },
             )
-            component = app["components"].get(pod["component"], {
-                "cost": 0,
-                "slack_cost": 0,
-                "pods": 0,
-                "requests": {},
-                "usage": {},
-                "clusters": set(),
-            })
+            component = app["components"].get(
+                pod["component"],
+                {
+                    "cost": 0,
+                    "slack_cost": 0,
+                    "pods": 0,
+                    "requests": {},
+                    "usage": {},
+                    "clusters": set(),
+                },
+            )
             for r in "cpu", "memory":
                 app["requests"][r] = app["requests"].get(r, 0) + pod["requests"][r]
                 app["usage"][r] = app["usage"].get(r, 0) + pod.get("usage", {}).get(
                     r, 0
                 )
-                component["requests"][r] = component["requests"].get(r, 0) + pod["requests"][r]
-                component["usage"][r] = component["usage"].get(r, 0) + pod.get("usage", {}).get(
-                    r, 0
+                component["requests"][r] = (
+                    component["requests"].get(r, 0) + pod["requests"][r]
                 )
+                component["usage"][r] = component["usage"].get(r, 0) + pod.get(
+                    "usage", {}
+                ).get(r, 0)
             app["cost"] += pod["cost"]
             app["slack_cost"] += pod.get("slack_cost", 0)
             app["pods"] += 1

--- a/kube_resource_report/templates/application.html
+++ b/kube_resource_report/templates/application.html
@@ -103,6 +103,93 @@
     </table>
 </div>
 
+<div class="section collapsible" data-name="components">
+    <h2 class="title is-5">Components</h2>
+    <table class="table is-striped is-hoverable is-fullwidth" data-sortable>
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th><abbr title="Clusters">C</abbr></th>
+                <th><abbr title="Pods">P</abbr></th>
+                <th><abbr title="CPU Requests">CR</abbr></th>
+                <th><abbr title="Memory Requests">MR</abbr></th>
+                <th>CPU</th>
+                <th>Memory (MiB)</th>
+                <th class="has-text-right">Cost</th>
+                <th class="has-text-right">Slack Cost</th>
+                <th class="has-text-right">Cost %</th>
+                {% if links['component']: %}
+                <th></th>
+                {% endif %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for name, component in application.components.items()|sort: %}
+            <tr>
+                <td>{{ name }}</td>
+                <td title="{{ component.clusters|join(', ') }}">{{ component.clusters|count }}</td>
+                <td>{{ component.pods }}</td>
+                <td>{{ component.requests.cpu|round(3) }}</td>
+                <td data-value="{{ component.requests.memory }}">{{ component.requests.memory|filesizeformat(True) }}</td>
+
+                <td style="font-size: 0.75rem" data-value="{{ component.usage.cpu }}">
+                    <div class="resource-labels">
+                        <span>{{ component.usage.cpu|round(2) }}</span> <span>{{ component.requests.cpu|round(2) }}</span>
+                    </div>
+                    <div class="resource-bar" title="Usage in green; requested in black; usage > requested in red.">
+                        <progress class="progress" value="{{ component.requests.cpu }}" max="{{ component.requests.cpu }}"></progress>
+                        <progress class="progress {{ 'is-danger' if component.usage.cpu > component.requests.cpu else 'is-primary' }}" value="{{ component.usage.cpu }}" max="{{ component.requests.cpu }}"></progress>
+                    </div>
+                </td>
+                <td style="font-size: 0.75rem" data-value="{{ component.usage.memory }}">
+                    <div class="resource-labels">
+                        <span>{{ component.usage.memory|memory('MiB') }}</span> <span>{{ component.requests.memory|memory('MiB') }}</span>
+                    </div>
+                    <div class="resource-bar" title="Usage in green; requested in black; usage > requested in red.">
+                        <progress class="progress" value="{{ component.requests.memory }}" max="{{ component.requests.memory }}"></progress>
+                        <progress class="progress {{ 'is-danger' if component.usage.memory > component.requests.memory else 'is-primary' }}" value="{{ component.usage.memory }}" max="{{ component.requests.memory }}"></progress>
+                    </div>
+                </td>
+
+                <td class="has-text-right">{{ component.cost|money }}</td>
+                <td class="has-text-right">{{ component.slack_cost|money }}</td>
+
+                {% if application.cost > 0 %}
+                {% with percentage=(component.cost / application.cost) * 100 %}
+                <td style="font-size: 0.75rem" data-value="{{ percentage|round(3) }}">
+                    <div class="resource-labels">
+                        <span>{{ percentage|round(0)|int }}%</span> <span></span>
+                    </div>
+                    <div class="resource-bar" title="Percentage of component cost divided by application cost">
+                        <progress class="progress" value="100" max="100"></progress>
+                        <progress class="progress is-primary" value="{{ percentage|round(3) }}" max="100"></progress>
+                    </div>
+                </td>
+                {% endwith %}
+                {% else %}
+                <td class="has-text-right">-</td>
+                {% endif %}
+
+                {% if links['component']: %}
+                <td class="links">
+                    <div class="buttons has-addons">
+                        {% for link in links['component']: %}
+                        <a href="{{ link.href.format(app=application.id, name=name) }}"
+                           title="{{ link.title.format(app=application.id, name=name) }}"
+                           class="button is-small">
+                            <span class="icon"><i class="fas fa-{{ link.icon }}"></i></span>
+                        </a>
+                        {% endfor %}
+                    </div>
+                </td>
+                {% endif %}
+            </tr>
+            {%endfor %}
+        </tbody>
+
+    </table>
+</div>
+
 <div class="section collapsible" data-name="pods">
     <h2 class="title is-5">Pods</h2>
     <table class="table is-striped is-hoverable is-fullwidth" data-sortable>

--- a/kube_resource_report/templates/application.html
+++ b/kube_resource_report/templates/application.html
@@ -126,7 +126,7 @@
         <tbody>
             {% for name, component in application.components.items()|sort: %}
             <tr>
-                <td>{{ name }}</td>
+                <td>{% if name == "": %}<i>unnamed</i>{% else %}{{ name }}{% endif %}</td>
                 <td title="{{ component.clusters|join(', ') }}">{{ component.clusters|count }}</td>
                 <td>{{ component.pods }}</td>
                 <td>{{ component.requests.cpu|round(3) }}</td>


### PR DESCRIPTION
Elevate components to higher class citizen by showing summaries of (potentially) complex, multi-pod, cross-cluster components on application page.

Supports unnamed components

<img width="1406" alt="Screen Shot 2020-04-09 at 22 30 57" src="https://user-images.githubusercontent.com/102791/78938090-e8b1fc00-7ab1-11ea-9c07-43f3bcc80f60.png">
