### PR TITLE
Defers execution of sortable script

### DIFF
--- a/kube_resource_report/templates/base.html
+++ b/kube_resource_report/templates/base.html
@@ -7,7 +7,7 @@
         <title>{% block title %}{% endblock %} - Kubernetes Resource Report</title>
         <link rel="stylesheet" href="assets/bulma.min.css">
         <script defer src="assets/all.js"></script>
-        <script src="assets/sortable.min.js"></script>
+        <script defer src="assets/sortable.min.js"></script>
         <script src="assets/anchor.min.js"></script>
         <script src="assets/kube-resource-report.js"></script>
         <link rel="stylesheet" href="assets/sortable-theme-minimal.css" />


### PR DESCRIPTION
sortable.js does not wait until html is fully parsed therefore some
tables on a large page may stay unsortable

See https://flaviocopes.com/javascript-async-defer/