### PR TITLE
Allow customization of `NODE_LABEL_SPOT_VALUE`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,7 @@ You can run ``docker run --rm hjacobs/kube-resource-report:20.4.4 --help`` to fi
 Besides this, you can also pass environment variables:
 
 - ``NODE_LABEL_SPOT`` (default: ``"aws.amazon.com/spot"``)
+- ``NODE_LABEL_SPOT_VALUE`` (default: ``"true"``)
 - ``NODE_LABEL_PREEMPTIBLE`` (default: ``cloud.google.com/gke-preemptible``)
 - ``NODE_LABEL_ROLE`` (default: ``"kubernetes.io/role"``)
 - ``NODE_LABEL_REGION`` (default: ``"failure-domain.beta.kubernetes.io/region"``)

--- a/kube_resource_report/query.py
+++ b/kube_resource_report/query.py
@@ -32,6 +32,7 @@ from kube_resource_report import metrics
 from kube_resource_report import pricing
 
 NODE_LABEL_SPOT = os.environ.get("NODE_LABEL_SPOT", "aws.amazon.com/spot")
+NODE_LABEL_SPOT_VALUE = os.environ.get("NODE_LABEL_SPOT_VALUE", "true")
 NODE_LABEL_PREEMPTIBLE = os.environ.get(
     "NODE_LABEL_PREEMPTIBLE", "cloud.google.com/gke-preemptible"
 )
@@ -161,7 +162,7 @@ def map_node(_node: Node):
     role = _node.labels.get(NODE_LABEL_ROLE) or "worker"
     region = _node.labels.get(NODE_LABEL_REGION, "unknown")
     instance_type = _node.labels.get(NODE_LABEL_INSTANCE_TYPE, "unknown")
-    is_spot = _node.labels.get(NODE_LABEL_SPOT) == "true"
+    is_spot = _node.labels.get(NODE_LABEL_SPOT) == NODE_LABEL_SPOT_VALUE
     is_preemptible = _node.labels.get(NODE_LABEL_PREEMPTIBLE, "false") == "true"
     if is_preemptible:
         instance_type = instance_type + "-preemptible"


### PR DESCRIPTION
In our environment, we label nodes with an instance lifecycle tag, similar to:

```
example.com/instance-lifecycle=spot
example.com/instance-lifecycle=ondemand
```

This allows overriding the comparison value of the node spot label, to support this labelling pattern, where the value isn't `true`