### PR TITLE
Allow overriding default cluster name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,7 @@ You can run ``docker run --rm hjacobs/kube-resource-report:20.4.4 --help`` to fi
 
 Besides this, you can also pass environment variables:
 
+- ``DEFAULT_CLUSTER_NAME`` (default: ``"cluster"``)
 - ``NODE_LABEL_SPOT`` (default: ``"aws.amazon.com/spot"``)
 - ``NODE_LABEL_SPOT_VALUE`` (default: ``"true"``)
 - ``NODE_LABEL_PREEMPTIBLE`` (default: ``cloud.google.com/gke-preemptible``)

--- a/kube_resource_report/cluster_discovery.py
+++ b/kube_resource_report/cluster_discovery.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import time
 from pathlib import Path
@@ -13,6 +14,7 @@ from requests.auth import AuthBase
 
 # default URL points to kubectl proxy
 DEFAULT_CLUSTERS = "http://localhost:8001/"
+DEFAULT_CLUSTER_NAME = os.environ.get("DEFAULT_CLUSTER_NAME", "cluster")
 CLUSTER_ID_INVALID_CHARS = re.compile("[^a-z0-9:-]")
 
 logger = logging.getLogger(__name__)
@@ -64,7 +66,7 @@ class StaticClusterDiscoverer:
                 client = HTTPClient(config)
                 cluster = Cluster(
                     generate_cluster_id(DEFAULT_CLUSTERS),
-                    "cluster",
+                    DEFAULT_CLUSTER_NAME,
                     DEFAULT_CLUSTERS,
                     client,
                 )
@@ -72,7 +74,7 @@ class StaticClusterDiscoverer:
                 client = HTTPClient(config)
                 cluster = Cluster(
                     generate_cluster_id(config.cluster["server"]),
-                    "cluster",
+                    DEFAULT_CLUSTER_NAME,
                     config.cluster["server"],
                     client,
                 )


### PR DESCRIPTION
Support setting a different cluster name other than `cluster`.

In our environment, we have colloquial names for our clusters, and run a report in each, so being able to have the cluster name there for vanity is 💯 