### PR TITLE
Added node report and associated links

### DIFF
--- a/kube_resource_report/query.py
+++ b/kube_resource_report/query.py
@@ -149,6 +149,8 @@ def map_node(_node: Node):
     node["allocatable"] = {}
     node["requests"] = new_resources()
     node["usage"] = new_resources()
+    node["pods"] = {}
+    node["slack_cost"] = 0
 
     status = _node.obj["status"]
     for k, v in status.get("capacity", {}).items():
@@ -285,6 +287,7 @@ def query_cluster(
                 user_requests[k] += v
         node_name = pod.obj["spec"].get("nodeName")
         if node_name and node_name in nodes:
+            pod_["node"] = node_name
             for k in ("cpu", "memory"):
                 nodes[node_name]["requests"][k] += pod_["requests"].get(k, 0)
         found_vpa = False
@@ -364,6 +367,11 @@ def query_cluster(
             pod["recommendation"]["memory"] * cost_per_memory,
         )
         pod["slack_cost"] = max(min(pod["cost"] - usage_cost, pod["cost"]), 0)
+        if "node" in pod.keys():
+            node_name = pod["node"]
+            if node_name and node_name in nodes:
+                node = nodes[node_name]
+                node["slack_cost"] += pod["slack_cost"]
         cluster_slack_cost += pod["slack_cost"]
 
     cluster_summary["slack_cost"] = min(cluster_cost, cluster_slack_cost)

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -382,6 +382,7 @@ def generate_report(
         for node_name, node in summary["nodes"].items():
             node["node_name"] = node_name
             node["cluster"] = cluster_id
+            node["cluster_name"] = cluster_summaries[cluster_id]["cluster"].name
             nodes[f"{cluster_id}.{node_name}"] = node
 
     if application_registry:

--- a/kube_resource_report/report.py
+++ b/kube_resource_report/report.py
@@ -295,6 +295,7 @@ def generate_report(
 
     applications: Dict[str, dict] = {}
     namespace_usage: Dict[tuple, dict] = {}
+    nodes: Dict[str, dict] = {}
 
     for cluster_id, summary in sorted(cluster_summaries.items()):
         for _k, pod in summary["pods"].items():
@@ -378,6 +379,11 @@ def generate_report(
             namespace["cluster"] = summary["cluster"]
             namespace_usage[(ns_pod[0], cluster_id)] = namespace
 
+        for node_name, node in summary["nodes"].items():
+            node["node_name"] = node_name
+            node["cluster"] = cluster_id
+            nodes[f"{cluster_id}.{node_name}"] = node
+
     if application_registry:
         resolve_application_ids(applications, application_registry)
 
@@ -425,6 +431,7 @@ def generate_report(
         start,
         notifications,
         cluster_summaries,
+        nodes,
         namespace_usage,
         applications,
         teams,
@@ -451,6 +458,7 @@ def write_loading_page(out):
 def write_tsv_files(
     out: OutputManager,
     cluster_summaries,
+    nodes,
     namespace_usage,
     applications,
     teams,
@@ -496,6 +504,43 @@ def write_tsv_files(
                 ]
             fields += [round(summary["cost"], 2)]
             fields += [round(summary["slack_cost"], 2)]
+            writer.writerow(fields)
+
+    with out.open("nodes.tsv") as csvfile:
+        writer = csv.writer(csvfile, delimiter="\t")
+        headers = [
+            "Cluster ID",
+            "Node",
+            "Role",
+            "Instance Type",
+            "Spot Instance",
+            "Kubelet Version",
+        ]
+        for x in resource_categories:
+            headers.extend([f"CPU {x.capitalize()}", f"Memory {x.capitalize()} [MiB]"])
+        headers.append("Cost [USD]")
+        writer.writerow(headers)
+        for _, node in sorted(nodes.items()):
+            instance_type = set()
+            kubelet_version = set()
+            if node["role"] in node_labels:
+                instance_type.add(node["instance_type"])
+            kubelet_version.add(node["kubelet_version"])
+
+            fields = [
+                node["cluster"],
+                node["node_name"],
+                node["role"],
+                node["instance_type"],
+                "Yes" if node["spot"] else "No",
+                node["kubelet_version"],
+            ]
+            for x in resource_categories:
+                fields += [
+                    round(node[x]["cpu"], 2),
+                    int(node[x]["memory"] / ONE_MEBI),
+                ]
+            fields += [round(node["cost"], 2)]
             writer.writerow(fields)
 
     with out.open("ingresses.tsv") as csvfile:
@@ -790,6 +835,8 @@ def write_html_files(
     context,
     alpha_ema,
     cluster_summaries,
+    nodes,
+    pods_by_node,
     teams,
     applications,
     ingresses_by_application,
@@ -798,6 +845,7 @@ def write_html_files(
     for page in [
         "index",
         "clusters",
+        "nodes",
         "ingresses",
         "teams",
         "applications",
@@ -816,6 +864,15 @@ def write_html_files(
         context["cluster_id"] = cluster_id
         context["summary"] = summary
         out.render_template("cluster.html", context, file_name)
+
+    for node_id, node in nodes.items():
+        page = "nodes"
+        file_name = f"node-{node_id}.html"
+        context["page"] = page
+        context["cluster_id"] = cluster_id
+        context["node"] = node
+        context["pods"] = pods_by_node[node_id]
+        out.render_template("node.html", context, file_name)
 
     for team_id, team in teams.items():
         page = "teams"
@@ -840,6 +897,7 @@ def write_report(
     start,
     notifications,
     cluster_summaries,
+    nodes,
     namespace_usage,
     applications,
     teams,
@@ -848,7 +906,7 @@ def write_report(
     alpha_ema: float,
 ):
     write_tsv_files(
-        out, cluster_summaries, namespace_usage, applications, teams, node_labels
+        out, cluster_summaries, nodes, namespace_usage, applications, teams, node_labels
     )
 
     total_allocatable: dict = collections.defaultdict(int)
@@ -889,6 +947,24 @@ def write_report(
                 }
             )
 
+    pods_by_node: Dict[str, list] = collections.defaultdict(list)
+    for cluster_id, summary in cluster_summaries.items():
+        for namespace_name, pod in summary["pods"].items():
+            namespace, name = namespace_name
+            if "node" not in pod.keys():
+                continue
+            node_name = pod["node"]
+            node_id = f"{cluster_id}.{node_name}"
+            pods_by_node[node_id].append(
+                {
+                    "cluster_id": cluster_id,
+                    "node": nodes[node_id],
+                    "namespace": namespace,
+                    "name": name,
+                    "pod": pod,
+                }
+            )
+
     total_cost = sum([s["cost"] for s in cluster_summaries.values()])
     total_hourly_cost = total_cost / HOURS_PER_MONTH
     now = datetime.datetime.utcnow()
@@ -896,6 +972,7 @@ def write_report(
         "links": links,
         "notifications": notifications,
         "cluster_summaries": cluster_summaries,
+        "nodes": nodes,
         "teams": teams,
         "applications": applications,
         "namespace_usage": namespace_usage,
@@ -941,6 +1018,8 @@ def write_report(
         context,
         alpha_ema,
         cluster_summaries,
+        nodes,
+        pods_by_node,
         teams,
         applications,
         ingresses_by_application,

--- a/kube_resource_report/templates/cluster.html
+++ b/kube_resource_report/templates/cluster.html
@@ -83,7 +83,7 @@
         <tbody>
             {% for node_name, node in summary.nodes.items()|sort: %}
             <tr>
-                <td>{{ node_name }}</td>
+                <td><a href="./node-{{ summary.cluster.id }}.{{ node_name }}.html">{{ node_name }}</a></td>
                 <td>{{ node.role }}</td>
                 <td>{{ node.instance_type }}</td>
                 <td>{% if node.spot: %}

--- a/kube_resource_report/templates/node.html
+++ b/kube_resource_report/templates/node.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+{% block title %}Node {{ node.node_name }}{% endblock %}
+{% block content %}
+<h1 class="title">Node {{ node.node_name }}
+    <span class="links">
+        {% for link in links['node']: %}
+        <a href="{{ link.href.format(cluster=summary.cluster.name, name=node_name) }}"
+           title="{{ link.title.format(cluster=summary.cluster.name, name=node_name) }}"
+           class="button {{ link.class or 'is-light' }}">
+            <span class="icon"><i class="fas fa-{{ link.icon }}"></i></span>
+        </a>
+        {% endfor %}
+    </span>
+</h1>
+<h2 class="subtitle"><a href="./cluster-{{ summary.cluster.id }}.html">{{ summary.cluster.name }}</a> / {{ node.instance_type }}</h2>
+
+<nav class="level">
+    <div class="level-item has-text-centered">
+        <div>
+            <p class="heading">Pods</p>
+            <p class="title">{{ pods|count }}</p>
+        </div>
+    </div>
+    <div class="level-item has-text-centered">
+        <div>
+            <p class="heading">CPU Requests / Allocatable</p>
+            <p class="title">{{ node.requests.cpu|cpu }} / {{ node.allocatable.cpu|cpu }}</p>
+        </div>
+    </div>
+    <div class="level-item has-text-centered">
+        <div>
+            <p class="heading">Memory Requests / Allocatable</p>
+            <p class="title">{{ node.requests.memory|filesizeformat(True) }} / {{ node.allocatable.memory|filesizeformat(True) }}</p>
+        </div>
+    </div>
+    <div class="level-item has-text-centered">
+        <div>
+            <p class="heading">Monthly Cost</p>
+            <p class="title">{{ node.cost|money }} USD</p>
+        </div>
+    </div>
+</nav>
+<div class="notification is-warning">
+    You can potentially save <strong>{{ node.slack_cost|money }} USD</strong> every month by optimizing resource requests and reducing slack.
+</div>
+
+<div class="section collapsible" data-name="pods">
+    <h2 class="title is-5">Pods</h2>
+    <table class="table is-striped is-hoverable is-fullwidth" data-sortable>
+        <thead>
+            <tr>
+                <th>Cluster</th>
+                <th>Namespace</th>
+                <th>Component</th>
+                <th>Name</th>
+                <th><abbr title="Container Images">Cont.</abbr></th>
+                <th><abbr title="CPU Requests">CR</abbr></th>
+                <th><abbr title="Memory Requests">MR</abbr></th>
+                <th>CPU</th>
+                <th>Memory (MiB)</th>
+                <th class="has-text-right">Cost</th>
+                <th class="has-text-right">Slack Cost</th>
+                {% if links['pod']: %}
+                <th></th>
+                {% endif %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in pods: %}
+            <tr>
+                <td><a href="./cluster-{{ row.cluster_id }}.html">{{ summary.cluster.name }}</a></td>
+                <td>{{ row.namespace }}</td>
+                <td>{{ row.pod.component }}</td>
+                <td>{{ row.name }}</td>
+                <td title="{{ row.pod.container_images|join(', ') }}">{{ row.pod.container_images|count }}</td>
+                <td>{{ row.pod.requests.cpu|round(3) }}</td>
+                <td data-value="{{ row.pod.requests.memory }}">{{ row.pod.requests.memory|filesizeformat(True) }}</td>
+
+                <td style="font-size: 0.75rem" data-value="{{ row.pod.usage.cpu }}">
+                    {{ elements.resource_bar_cpu(row.pod) }}
+                </td>
+                <td style="font-size: 0.75rem" data-value="{{ row.pod.usage.memory }}">
+                    {{ elements.resource_bar_memory(row.pod) }}
+                </td>
+
+                <td class="has-text-right">{{ row.pod.cost|money }}</td>
+                <td class="has-text-right">{{ row.pod.slack_cost|money }}</td>
+
+                {% if links['pod']: %}
+                <td class="links">
+                    <div class="buttons has-addons">
+                        {% for link in links['pod']: %}
+                        <a href="{{ link.href.format(cluster=summary.cluster.name, namespace=row.namespace, name=row.name) }}"
+                           title="{{ link.title.format(cluster=summary.cluster.name, namespace=row.namespace, name=row.name) }}"
+                           class="button is-small">
+                            <span class="icon"><i class="fas fa-{{ link.icon }}"></i></span>
+                        </a>
+                        {% endfor %}
+                    </div>
+                </td>
+                {% endif %}
+            </tr>
+            {%endfor %}
+        </tbody>
+
+    </table>
+</div>
+{% endblock %}

--- a/kube_resource_report/templates/nodes.html
+++ b/kube_resource_report/templates/nodes.html
@@ -34,7 +34,7 @@
     <tbody>
         {% for node_id, node in nodes.items()|sort: %}
             <tr>
-                <td><a href="./cluster-{{ node.cluster }}.html">{{ node.cluster }}</a></td>
+                <td><a href="./cluster-{{ node.cluster }}.html">{{ node.cluster_name }}</a></td>
                 <td><a href="./node-{{ node_id }}.html">{{ node.node_name }}</a></td>
                 <td>{{ node.role }}</td>
                 <td>{{ node.instance_type }}</td>

--- a/kube_resource_report/templates/nodes.html
+++ b/kube_resource_report/templates/nodes.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% block title %}Nodes{% endblock %}
+{% block content %}
+
+<h1 class="title">All Nodes
+    <span class="links">
+        <a href="./nodes.tsv"
+           title="Download Nodes as Tab-Separated-Values (TSV)"
+           class="button is-light">
+            <span class="icon"><i class="fas fa-file-download"></i></span>
+        </a>
+    </span>
+</h1>
+
+<table class="table is-striped is-hoverable is-fullwidth" data-sortable>
+    <thead>
+        <tr>
+            <th>Cluster</th>
+            <th>Name</th>
+            <th>Role</th>
+            <th>Instance Type</th>
+            <th><abbr title="Spot Instance?">S?</abbr></th>
+            <th>Version</th>
+            <th><abbr title="CPU Capacity">CC</abbr></th>
+            <th><abbr title="Memory Capacity">MC</abbr></th>
+            <th>CPU</th>
+            <th>Memory (GiB)</th>
+            <th>Cost</th>
+            {% if links['node']: %}
+            <th></th>
+            {% endif %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for node_id, node in nodes.items()|sort: %}
+            <tr>
+                <td><a href="./cluster-{{ node.cluster }}.html">{{ node.cluster }}</a></td>
+                <td><a href="./node-{{ node_id }}.html">{{ node.node_name }}</a></td>
+                <td>{{ node.role }}</td>
+                <td>{{ node.instance_type }}</td>
+                <td>{% if node.spot: %}
+                    <span class="icon"><i class="fas fa-percentage has-text-success"></i></span>
+                    {% endif %}
+                </td>
+                <td>{{ node.kubelet_version }}</td>
+                <td class="has-text-right">{{ node.capacity.cpu|round(1) }}</td>
+                <td class="has-text-right">{{ node.capacity.memory|filesizeformat(True) }}</td>
+
+                <td style="font-size: 0.75rem" data-value="{{ node.usage.cpu }}">
+                    <div class="resource-labels">
+                        <span>{{ node.usage.cpu|round(1) }}</span>
+                        <span>{{ node.requests.cpu|round(1) }}</span>
+                        <span>{{ node.allocatable.cpu|round(1) }}</span>
+                    </div>
+                    <div class="resource-bar" title="Usage in green; requested in black; allocatable in grey.">
+                        <progress class="progress" value="{{ node.requests.cpu }}" max="{{ node.allocatable.cpu }}"></progress>
+                        <progress class="progress is-primary" value="{{ node.usage.cpu }}" max="{{ node.allocatable.cpu }}"></progress>
+                    </div>
+                </td>
+                <td style="font-size: 0.75rem" data-value="{{ node.usage.memory }}">
+                    <div class="resource-labels">
+                        <span>{{ node.usage.memory|memory('GiB') }}</span>
+                        <span>{{ node.requests.memory|memory('GiB') }}</span>
+                        <span>{{ node.allocatable.memory|memory('GiB') }}</span>
+                    </div>
+                    <div class="resource-bar" title="Usage in green; requested in black; allocatable in grey.">
+                        <progress class="progress" value="{{ node.requests.memory }}" max="{{ node.allocatable.memory }}"></progress>
+                        <progress class="progress is-primary" value="{{ node.usage.memory }}" max="{{ node.allocatable.memory }}"></progress>
+                    </div>
+                </td>
+                <td class="has-text-right">{{ node.cost|money }}</td>
+
+                {% if links['node']: %}
+                <td class="links">
+                    <div class="buttons has-addons">
+                        {% for link in links['node']: %}
+                        <a href="{{ link.href.format(cluster=summary.cluster.name, name=node_name) }}"
+                           title="{{ link.title.format(cluster=summary.cluster.name, name=node_name) }}"
+                           class="button is-small">
+                            <span class="icon"><i class="fas fa-{{ link.icon }}"></i></span>
+                        </a>
+                        {% endfor %}
+                    </div>
+                </td>
+                {% endif %}
+            </tr>
+            {%endfor %}
+    </tbody>
+
+</table>
+{% endblock %}

--- a/kube_resource_report/templates/partials/navbar.html
+++ b/kube_resource_report/templates/partials/navbar.html
@@ -10,6 +10,7 @@
         <div class="navbar-start">
             <a class="navbar-item {{ 'is-active' if page == 'index' }}" href="index.html">Overview</a>
             <a class="navbar-item {{ 'is-active' if page == 'clusters' }}" href="clusters.html">Clusters</a>
+            <a class="navbar-item {{ 'is-active' if page == 'nodes' }}" href="nodes.html">Nodes</a>
             <a class="navbar-item {{ 'is-active' if page == 'ingresses' }}" href="ingresses.html">Ingresses</a>
             <a class="navbar-item {{ 'is-active' if page == 'teams' }}" href="teams.html">Teams</a>
             <a class="navbar-item {{ 'is-active' if page == 'applications' }}" href="applications.html">Applications</a>

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -13,10 +13,12 @@ def test_map_empty_node():
         "usage": {"cpu": 0, "memory": 0},
         "requests": {"cpu": 0, "memory": 0},
         "cost": 0,
+        "slack_cost": 0,
         "instance_type": "unknown",
         "kubelet_version": "",
         "role": "worker",
         "spot": False,
+        "pods": {},
     }
 
 
@@ -39,10 +41,12 @@ def test_map_gke_preemptible_node():
         "usage": {"cpu": 0, "memory": 0},
         "requests": {"cpu": 0, "memory": 0},
         "cost": 0,
+        "slack_cost": 0,
         "instance_type": "1-standard-2-preemptible",
         "kubelet_version": "",
         "role": "worker",
         "spot": True,
+        "pods": {},
     }
 
 


### PR DESCRIPTION
Added a new node report view, and associated links to individual node pages from the cluster report.

In our environment, we have a large number of heterogeneous nodes, and being able to view them individually for pod details is extremely helpful.

Also added the `slack_cost` rollup for nodes.

![image](https://user-images.githubusercontent.com/409207/81346488-36993000-906f-11ea-92d2-dfecfe93afd9.png)

![image](https://user-images.githubusercontent.com/409207/81346699-9263b900-906f-11ea-89d6-89cacdff29b5.png)
